### PR TITLE
Nodes can now be started from installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,16 +324,9 @@ install(DIRECTORY include/${PROJECT_NAME}/
         )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(FILES
-        launch/sim_loc_driver.launch
-        launch/sim_loc_driver_check.launch
-        launch/sim_loc_test_server.launch
-        launch/unittest_sim_loc_parser.launch
-        launch/verify_sim_loc_driver.launch
-        yaml/message_check_demo.yaml
-        yaml/message_check_default.yaml
-        yaml/sim_loc_driver.yaml
-        yaml/sim_loc_test_server.yaml
+install(DIRECTORY
+        launch
+        yaml
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
         )
 


### PR DESCRIPTION
YAML and launch files have been installed in a flattened directory structure. When starting the driver via launch file from the install directory some files couldn't be found due to that fact.