### PR TITLE
Deprecate ament_target_dependencies

### DIFF
--- a/sick_lidar_localization_driver/CMakeLists.txt
+++ b/sick_lidar_localization_driver/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
         add_compile_options(-std=c++14)
     endif()
     add_compile_options(-g -Wall -Wno-reorder -Wno-sign-compare -Wno-unused-local-typedefs -Wno-unused-parameter -Wno-unused-function -Wno-unused-result)
-    # add_compile_options(-Wshadow) # Note: compiler option -Wshadow generates a lot of warnings in ros header files. Therefore it's deactivated by default, but can be usefull for development and testing.
+    # add_compile_options(-Wshadow) # Note: compiler option -Wshadow generates a lot of warnings in ros header files. Therefore it's deactivated by default, but can be useful for development and testing.
     set(LINUX_LIBRARIES pthread)    # gcc maps std::thread to pthread, using std::thread requires linking with pthread
 endif()
 
@@ -52,11 +52,11 @@ elseif(ROS_VERSION EQUAL 2)
     find_package(nav_msgs REQUIRED)
     find_package(sensor_msgs REQUIRED)
     find_package(std_msgs REQUIRED)
-    find_package(tf2 REQUIRED)  
+    find_package(tf2 REQUIRED)
     find_package(tf2_ros REQUIRED)
     find_package(visualization_msgs REQUIRED)
     find_package(sick_lidar_localization_msgs REQUIRED)
-endif() 
+endif()
 
 ## packages required by sick_lidar_localization
 find_package(CURL REQUIRED)    # install libcurl by running "sudo apt-get install libcurl-dev" (Linux) resp. "vcpkg install curl[tool]:x64-windows" (Windows)
@@ -66,7 +66,7 @@ find_package(jsoncpp REQUIRED) # install libjsoncpp by running "sudo apt-get ins
 ## Build ##
 ###########
 
-if(ROS_VERSION EQUAL 1) 
+if(ROS_VERSION EQUAL 1)
     catkin_package(INCLUDE_DIRS include LIBRARIES sick_localization_lib CATKIN_DEPENDS roscpp rospy geometry_msgs nav_msgs sensor_msgs std_msgs sick_lidar_localization_msgs)
 endif()
 
@@ -91,7 +91,7 @@ add_library(sick_localization_lib ${LIB_TYPE}
     src/tinyxml/tinystr.cpp
     src/tinyxml/tinyxml.cpp
     src/tinyxml/tinyxmlerror.cpp
-    src/tinyxml/tinyxmlparser.cpp    
+    src/tinyxml/tinyxmlparser.cpp
 )
 target_link_libraries(sick_localization_lib ${CURL_LIBRARIES} jsoncpp_lib ${catkin_LIBRARIES} ${LINUX_LIBRARIES} ${WIN_LIBRARIES})
 
@@ -106,22 +106,44 @@ target_link_libraries(gen_service_call sick_localization_lib ${CURL_LIBRARIES} j
 if(ROS_VERSION GREATER 0)
     add_executable(lls_transform src/lls_transform.cpp src/lls_transform_thread.cpp)
     target_link_libraries(lls_transform sick_localization_lib ${CURL_LIBRARIES} jsoncpp_lib ${catkin_LIBRARIES})
-endif()     
+endif()
 
 if(ROS_VERSION EQUAL 1)
     add_dependencies(sick_localization_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
     add_dependencies(sick_lidar_localization_main sick_localization_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
     add_dependencies(lls_transform sick_localization_lib ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 elseif(ROS_VERSION EQUAL 2)
-    ament_target_dependencies(sick_localization_lib rclcpp geometry_msgs nav_msgs sensor_msgs std_msgs tf2_ros visualization_msgs sick_lidar_localization_msgs)
-    ament_target_dependencies(lls_transform rclcpp geometry_msgs nav_msgs sensor_msgs std_msgs tf2_ros visualization_msgs sick_lidar_localization_msgs)
+    target_link_libraries(sick_localization_lib
+        ${geometry_msgs_TARGETS}
+        ${nav_msgs_TARGETS}
+        ${sensor_msgs_TARGETS}
+        ${sick_lidar_localization_msgs_TARGETS}
+        ${std_msgs_TARGETS}
+        ${visualization_msgs_TARGETS}
+        rclcpp::rclcpp
+        sensor_msgs::sensor_msgs_library
+        tf2_ros::static_transform_broadcaster_node
+        tf2_ros::tf2_ros
+    )
+    target_link_libraries(lls_transform
+        ${geometry_msgs_TARGETS}
+        ${nav_msgs_TARGETS}
+        ${sensor_msgs_TARGETS}
+        ${sick_lidar_localization_msgs_TARGETS}
+        ${std_msgs_TARGETS}
+        ${visualization_msgs_TARGETS}
+        rclcpp::rclcpp
+        sensor_msgs::sensor_msgs_library
+        tf2_ros::static_transform_broadcaster_node
+        tf2_ros::tf2_ros
+    )
 else()
     add_dependencies(sick_lidar_localization_main sick_localization_lib)
-endif()     
+endif()
 
 #############
 ## Install ##
-############# 
+#############
 
 if(ROS_VERSION EQUAL 1)
     install(TARGETS sick_localization_lib sick_lidar_localization_main gen_service_call lls_transform ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION} LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION} RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
@@ -135,6 +157,6 @@ elseif(ROS_VERSION EQUAL 2)
     # install(TARGETS sick_localization_lib sick_lidar_localization_main gen_service_call lls_transform DESTINATION lib)
     install(TARGETS sick_localization_lib sick_lidar_localization_main gen_service_call lls_transform DESTINATION lib/${PROJECT_NAME})
     install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-else() 
+else()
     install(DIRECTORY launch DESTINATION ${CMAKE_BINARY_DIR})
-endif() 
+endif()


### PR DESCRIPTION
As per deprecation message:
```
  ament_target_dependencies() is deprecated.  Use target_link_libraries()
  with modern CMake targets instead.  Try replacing this call with:

    target_link_libraries(sick_localization_lib PUBLIC
      ${geometry_msgs_TARGETS}
      ${nav_msgs_TARGETS}
      ${sensor_msgs_TARGETS}
      ${sick_lidar_localization_msgs_TARGETS}
      ${std_msgs_TARGETS}
      ${visualization_msgs_TARGETS}
      rclcpp::rclcpp
      sensor_msgs::sensor_msgs_library
      tf2_ros::static_transform_broadcaster_node
      tf2_ros::tf2_ros
    )

  ament_target_dependencies() is deprecated.  Use target_link_libraries()
  with modern CMake targets instead.  Try replacing this call with:

    target_link_libraries(lls_transform PUBLIC
      ${geometry_msgs_TARGETS}
      ${nav_msgs_TARGETS}
      ${sensor_msgs_TARGETS}
      ${sick_lidar_localization_msgs_TARGETS}
      ${std_msgs_TARGETS}
      ${visualization_msgs_TARGETS}
      rclcpp::rclcpp
      sensor_msgs::sensor_msgs_library
      tf2_ros::static_transform_broadcaster_node
      tf2_ros::tf2_ros
    )
```