### PR TITLE
Fix result telegrams topic path in lls_transform.cpp

### DIFF
--- a/sick_lidar_localization_driver/src/lls_transform.cpp
+++ b/sick_lidar_localization_driver/src/lls_transform.cpp
@@ -88,7 +88,7 @@ int main(int argc, char** argv)
 
   ROS_INFO_STREAM("lls_transform started.");
 
-  std::string result_telegrams_topic = "localizationcontroller/out/localizationcontroller_result_message_0502"; // default topic to publish result port telegram messages (type LocResultPortTelegramMsg)
+  std::string result_telegrams_topic = "/localizationcontroller/out/localizationcontroller_result_message_0502"; // default topic to publish result port telegram messages (type LocResultPortTelegramMsg)
   //rosGetParam(nh, "result_telegrams_topic", result_telegrams_topic);
   
   // Init verifier to compare and check lls_loc_driver and lls_loc_test_server messages


### PR DESCRIPTION
Fix issue with subscribing to a topic in ROS1 caused by namespace mismatch.